### PR TITLE
Fix up some issues links

### DIFF
--- a/index.md
+++ b/index.md
@@ -45,18 +45,18 @@ Our current documents cover different aspects of the 'core' QUIC protocol, defin
   [Editors' Draft](https://quicwg.github.io/load-balancers/draft-ietf-quic-load-balancers.html) /
   [WG Draft](https://tools.ietf.org/html/draft-ietf-quic-load-balancers) /
   [Repo](https://github.com/quicwg/load-balancers/) /
-  [Open Issues](https://github.com/quicwg/load-balancers/issues?utf8=✓&q=is%3Aissue%20is%3Aopen%20label%3A-qpack%20label%3Adesign)
+  [Open Issues](https://github.com/quicwg/load-balancers/issues?utf8=✓&q=is%3Aissue%20is%3Aopen%20label%3Adesign)
 * **Extensions**
      * **Datagram**
       [Editors' Draft](https://quicwg.github.io/datagram/draft-ietf-quic-datagram.html) /
       [WG Draft](https://tools.ietf.org/html/draft-ietf-quic-datagram) /
       [Repo](https://github.com/quicwg/datagram/) /
-      [Open Issues](https://github.com/quicwg/datagram/issues?utf8=✓&q=is%3Aissue%20is%3Aopen%20label%3A-qpack%20label%3Adesign)
+      [Open Issues](https://github.com/quicwg/datagram/issues?utf8=✓&q=is%3Aissue%20is%3Aopen%20label%3Adesign)
      * **Version Negotiation**
       [Editors' Draft](https://quicwg.github.io/version-negotiation/draft-ietf-quic-version-negotiation.html) /
       [WG Draft](https://tools.ietf.org/html/draft-ietf-quic-version-negotiation) /
       [Repo](https://github.com/quicwg/version-negotiation/) /
-      [Open Issues](https://github.com/quicwg/version-negotiation/issues?utf8=✓&q=is%3Aissue%20is%3Aopen%20label%3A-qpack%20label%3Adesign)
+      [Open Issues](https://github.com/quicwg/version-negotiation/issues?utf8=✓&q=is%3Aissue%20is%3Aopen%20label%3Adesign)
 
 
 ## Implementing QUIC


### PR DESCRIPTION
The hyperlinks to the Issues pages for Load Balancers, Datagram, and Version Negotiation had a `label:-qpack` filter applied, and this PR removes those.

---

I also note that these links have a `label:design` filter, but these separate repos don't (currently) make use of that label. They seem to be using GitHub's default labels, though Load Balancers includes the `editorial` label that's present in base-drafts.

I've kept those `label:design` filters in this PR as I'm expecting those repos would probably standardise on the labeling system used by base-drafts. That filter may also need to be removed if that's not the case.