### PR TITLE
Fix style of responsive images

### DIFF
--- a/_layouts/front.html
+++ b/_layouts/front.html
@@ -21,7 +21,7 @@
             
       <div class="container">
         
-        <h1><img src="/asset/badge.png" class="img-responsive" alt="QUIC"></h1>
+        <h1><img src="/asset/badge.png" class="img-fluid" alt="QUIC"></h1>
 
         <div class="lead">
 


### PR DESCRIPTION
There're some flaws in browsing [quicwg.org](https://quicwg.org) in mobile browsers. Mainly because the `img-responsive` is no longer a valid class name, instead it becomes `img-fluid`. See [this](https://getbootstrap.com/docs/4.3/content/images/#responsive-images).