### PR TITLE
General housekeeping of the front page

### DIFF
--- a/_layouts/front.html
+++ b/_layouts/front.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML> 
+<!DOCTYPE HTML>
 
 <html lang="en">
   <head>
@@ -15,17 +15,32 @@
   </head>
   <body>
 
-<!--    
+<!--
     {- include navbar.html %}
 -->
-            
+
       <div class="container">
-        
+
         <h1><img src="/asset/badge.png" class="img-fluid" alt="QUIC"></h1>
 
         <div class="lead">
 
-        <p>QUIC is an <a href="https://www.ietf.org/">IETF</a> Working Group that is <a href="https://datatracker.ietf.org/wg/quic/about/">chartered</a> to deliver the next transport protocol for the Internet.</p>
+        <p>The <a href="https://www.ietf.org/">IETF</a> QUIC Working Group
+        produced QUIC version 1 — a UDP-based, stream-multiplexing, encrypted
+        transport protocol. The protocol itself is published as <a
+        href="https://www.rfc-editor.org/rfc/rfc9000.html">RFC 9000</a>, and
+        there are other related RFCs of note, see below.
+
+        <p>We are now <a
+        href="https://datatracker.ietf.org/wg/quic/about/">chartered</a> to be
+        the focal point for any QUIC-related work in the IETF. Our work covers
+        maintenance and evolution of published specifications, the deployability
+        of QUIC, and new extensions to QUIC.</p>
+
+        <p>The QUIC Working Group originated HTTP/3, the mapping of HTTP to
+        QUIC, and the QPACK header compression scheme. These are now maintained
+        by the <a href="https://httpwg.org">HTTP Working Group</a>.</p>
+
         <p><strong>See our <a href="https://github.com/quicwg/base-drafts/blob/master/CONTRIBUTING.md">contribution guidelines</a> if you want to work with us.</strong></p>
         </div>
 

--- a/index.md
+++ b/index.md
@@ -94,6 +94,11 @@ Our current documents cover different aspects of the 'core' QUIC protocol, defin
           [WG Draft](https://datatracker.ietf.org/doc/html/draft-ietf-quic-qlog-h3-events.html) /
           [Repo](https://github.com/quicwg/qlog/) /
           [Open Issues](https://github.com/quicwg/qlog/issues?utf8=✓&q=is%3Aissue%20is%3Aopen)
+      * **QUIC v2**
+        [Editors' Draft](https://quicwg.org/quic-v2/draft-ietf-quic-v2-ack-frequency.html) /
+        [WG Draft](https://datatracker.ietf.org/doc/html/draft-ietf-quic-v2) /
+        [Repo](https://github.com/quicwg/quic-v2/) /
+        [Open Issues](https://github.com/quicwg/draft-ietf-quic-v2/issues?utf8=✓&q=is%3Aissue%20is%3Aopen)
 
 
 ## Implementing QUIC

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ title: QUIC Working Group
 
 ## Upcoming Meetings
 
-[IETF 112, November 6-12, 2021] [Agenda](https://github.com/quicwg/wg-materials/blob/main/ietf112/agenda.md)
+* IETF 113, March 19-25, 2022 [Agenda] (TBC)
 
 ## Our Documents
 

--- a/index.md
+++ b/index.md
@@ -75,7 +75,7 @@ Our current documents cover different aspects of the 'core' QUIC protocol, defin
         [Open Issues](https://github.com/quicwg/quic-bit-grease/issues?utf8=✓&q=is%3Aissue%20is%3Aopen)
       * **Acknowledgement Frequency**
         [Editors' Draft](https://quicwg.org/ack-frequency/draft-ietf-quic-ack-frequency.html) /
-        [WG Draft](https://datatracker.ietf.org/doc/html/draft-ietf-quic-ack-frequency-00) /
+        [WG Draft](https://datatracker.ietf.org/doc/html/draft-ietf-quic-ack-frequency) /
         [Repo](https://github.com/quicwg/ack-frequency/) /
         [Open Issues](https://github.com/quicwg/ack-frequency/issues?utf8=✓&q=is%3Aissue%20is%3Aopen)
       * **qlog**


### PR DESCRIPTION
- update next IETF meeting date
- Update prose to reflect post-RFC9000 WG
- add QUIC v2 to main page
- don't point to specific ack-frequency draft
